### PR TITLE
Fix error with TMPDIR variables without a trailing slash

### DIFF
--- a/.profile
+++ b/.profile
@@ -70,7 +70,7 @@ function play {
     # Use "$*" so that quoting the requested song isn't necessary.
     youtube-dl --default-search=ytsearch: \
                --youtube-skip-dash-manifest \
-               --output="${TMPDIR:-/tmp/}%(title)s-%(id)s.%(ext)s" \
+               --output="${TMPDIR:-/tmp}/%(title)s-%(id)s.%(ext)s" \
                --restrict-filenames \
                --format="bestaudio[ext!=webm]" \
                --exec=afplay "$*"


### PR DESCRIPTION
The PAM module pam_tmpdir generates TMPDIR variables in the form 
"/tmp/user/1001" (without a trailing slash.) This makes the play function fail,
because tries to save the file in "/tmp/user/1001filename.mp3" which fails,
because /tmp/user has 711 permissions (drwx--x--x)

This patch fixes this by moving the slash.
